### PR TITLE
fix: update on ready to be menubar not app

### DIFF
--- a/electron/electron.ts
+++ b/electron/electron.ts
@@ -7,6 +7,6 @@ const mb = menubar({
     : `file://${path.join(__dirname, "../build/index.html")}`,
 });
 
-mb.app.on("ready", () => {
+mb.on("ready", () => {
   console.log("app is ready") //tslint:disable-line
 });


### PR DESCRIPTION
> quote from: https://github.com/maxogden/menubar/pull/228

> The 'ready' event from menubar is different from the 'ready' event from Electron's app.
